### PR TITLE
Added dialectOptions to require ssl

### DIFF
--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -25,5 +25,11 @@ module.exports = {
     use_env_variable: 'DATABASE_URL',
     dialect: 'postgres',
     seederStorage: 'sequelize',
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false,
+      },
+    },
   },
 };


### PR DESCRIPTION
All Heroku Postgres production databases require using SSL connections. Without setting the ssl key to true, a "no pg_hba.conf entry for host" error occur when migrating a container.